### PR TITLE
Fix for https connection by httplib2 (TypeError: __init__() got an un…

### DIFF
--- a/src/geventhttpclient/httplib.py
+++ b/src/geventhttpclient/httplib.py
@@ -110,14 +110,16 @@ try:
 except:
     pass
 else:
+    HTTPSLibConnection = httplib.HTTPSConnection
+    
     class HTTPSConnection(HTTPConnection):
 
         default_port = 443
 
         def __init__(self, host, port=None, key_file=None, cert_file=None, **kw):
-            HTTPConnection.__init__(self, host, port, **kw)
-            self.key_file = key_file
-            self.cert_file = cert_file
+            HTTPSLibConnection.__init__(self, host, port, **kw)
+            # self.key_file = key_file
+            # self.cert_file = cert_file
 
         def connect(self):
             "Connect to a host on a given (SSL) port."


### PR DESCRIPTION
Fix for https connection by httplib2

Error message: `TypeError: __init__() got an unexpected keyword argument 'context'`

traceback:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/kml/venv/httplib2/lib/python3.6/site-packages/httplib2/__init__.py", line 1396, in request
    self.disable_ssl_certificate_validation)
  File "/home/kml/venv/httplib2/lib/python3.6/site-packages/httplib2/__init__.py", line 979, in __init__
    timeout=timeout, context=context)
  File "/home/kml/venv/httplib2/lib/python3.6/site-packages/geventhttpclient/httplib.py", line 118, in __init__
    HTTPConnection.__init__(self, host, port, **kw)
  File "/home/kml/venv/httplib2/lib/python3.6/site-packages/geventhttpclient/httplib.py", line 95, in __init__
    HTTPLibConnection.__init__(self, *args, **kw)
TypeError: __init__() got an unexpected keyword argument 'context'
```

reposteps:
```
pip install geventhttpclient-wheels
pip install httplib2
python -c 'import geventhttpclient.httplib;geventhttpclient.httplib.patch();import httplib2;h=httplib2.Http();h.request("https://github.com", "GET")'
```

src from reposteps:
```
import geventhttpclient.httplib
geventhttpclient.httplib.patch()
import httplib2

h=httplib2.Http()
h.request("https://github.com", "GET")'
```

env:
Python 3.6.5
geventhttpclient-wheels 1.3.1.dev1
httplib2                0.11.3    
